### PR TITLE
Checks that `getForPackageVersion()` has returned a `ConstraintInterface`

### DIFF
--- a/src/Exception/PatchAlreadyApplied.php
+++ b/src/Exception/PatchAlreadyApplied.php
@@ -26,7 +26,12 @@ class PatchAlreadyApplied extends Exception
         $this->patch = $patch;
         $message = (string) $message;
         if ($message === '') {
-            $message = 'The patch "'.$patch->getDescription().'" for '.$patch->getForPackageVersion()->getPrettyString().' provided by '.$patch->getFromPackage()->__toString().' is already applied.';
+            $packageVersion = $patch->getForPackageVersion();
+            $message = 'The patch "'.$patch->getDescription().'"';
+            if (!is_null($packageVersion)) {
+                $message .= ' for '.$packageVersion->getPrettyString();
+            }
+            $message .= ' provided by '.$patch->getFromPackage()->__toString().' is already applied.';
         }
         parent::__construct($message);
     }

--- a/src/Exception/PatchAlreadyApplied.php
+++ b/src/Exception/PatchAlreadyApplied.php
@@ -25,10 +25,10 @@ class PatchAlreadyApplied extends Exception
     {
         $this->patch = $patch;
         $message = (string) $message;
-        if ($message === '') {
+        if ('' === $message) {
             $packageVersion = $patch->getForPackageVersion();
             $message = 'The patch "'.$patch->getDescription().'"';
-            if (!is_null($packageVersion)) {
+            if (null !== $packageVersion) {
                 $message .= ' for '.$packageVersion->getPrettyString();
             }
             $message .= ' provided by '.$patch->getFromPackage()->__toString().' is already applied.';


### PR DESCRIPTION
If you use a configuration **without** package versions specified it only works on the initial `composer install`.

```json
{
    "patches": {
        "vendor/project": {
            "Patch description": "https://www.example.com/remote.patch",
        }
    }
}
```

 The next time `composer install` is run a `PatchAlreadyApplied` exception is raised, but fails when the constructor tries to get the package version:

```php
// $patch->getForPackageVersion() returns null
$message = 'The patch "'.$patch->getDescription().'" for '.$patch->getForPackageVersion()->getPrettyString().' provided by '.$patch->getFromPackage()->__toString().' is already applied.';
```