### PR TITLE
Support patches located in the RootPackage

### DIFF
--- a/src/PatchCollector.php
+++ b/src/PatchCollector.php
@@ -143,7 +143,12 @@ class PatchCollector
         if (!is_array($patches)) {
             $this->handleException(Exception\InvalidPackageConfigurationValue($package, 'extra.patches', $patches, 'The extra.patches configuration must be an array.'));
         } else {
-            $packageDirectory = $this->installationManager->getInstallPath($package);
+            // If the package is the RootPackage, we won't be able to get its install path from the installationmanager
+            if ($package instanceof RootPackageInterface) {
+                $packageDirectory = getcwd();
+            } else {
+                $packageDirectory = $this->installationManager->getInstallPath($package);
+            }
             foreach ($patches as $forPackageHandle => $patchList) {
                 if (!is_array($patchList)) {
                     $this->handleException(Exception\InvalidPackageConfigurationValue($package, 'extra.patches', $package, "The \"{$forPackageHandle}\" value must be an array."));


### PR DESCRIPTION
This allows us to do the following:

1. Declare patches on the root package:
```
"extra": {
    "patches": {
        "thingto/patch": {
            "Patch Description": "relative/path/to/patch.patch"
         }
    }
}
```
2. Create a patch file at `./relative/path/to/patch.patch`
3. Run composer install

The reason someone might want to do this is it eliminates the need to have patches located in a separate composer repository. So if you need to make a patch to a single repository you avoid a few steps.